### PR TITLE
chanreg and misc changes

### DIFF
--- a/ircd/ircd.yaml
+++ b/ircd/ircd.yaml
@@ -472,7 +472,7 @@ accounts:
         # account name as their nickname. when combined with strict nickname
         # enforcement, this lets users treat nicknames and account names
         # as equivalent for the purpose of ban/invite/exception lists.
-        force-nick-equals-account: true
+        force-nick-equals-account: true # TODO: Ease of transition and practical ramifications need confirmation
 
         # parallel setting to force-nick-equals-account: if true, this forbids
         # anonymous users (i.e., users not logged into an account) to change their
@@ -563,14 +563,14 @@ channels:
 
         # restrict new channel registrations to operators only?
         # (operators can then transfer channels to regular users using /CS TRANSFER)
-        operator-only: false
+        operator-only: true
 
         # how many channels can each account register?
         max-channels-per-account: 15
 
     # as a crude countermeasure against spambots, anonymous connections younger
     # than this value will get an empty response to /LIST (a time period of 0 disables)
-    list-delay: 0s
+    list-delay: 5s
 
     # INVITE to an invite-only channel expires after this amount of time
     # (0 or omit for no expiration):


### PR DESCRIPTION
channel-registrations require operator capability and `/cs transfer` can be used to grant users ownership. The requests will have to be manually mentioned in `#help` or as a `bot` command.

`force-nick-equals-account: true` will not make people happy since your nick is static and is always the same as your account name. While it solves this annoyance of people using nicks such as `nick|drug1 drug2 drug3`, and also makes it easier to keep track of registered users, it reduces incentive to register at times. Apparently there are ramifications to this for multi-client use and replay-history for device-ids. But the exact ramifications aren't clear.

Most spambots perform  a `/list` upon connect and choose channels with higher user count and then send spam link this crude deterrent is a test to see if this in any way inhibits that.